### PR TITLE
Allow Legacy ^1.0 Easy Admin Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   "require": {
     "php": "~7.2.0",
     "symfony/framework-bundle": "^4.1",
-    "easycorp/easyadmin-bundle": "^2.0",
+    "easycorp/easyadmin-bundle": "^2.0|^1.0",
     "gedmo/doctrine-extensions": "^2.4"
   },
   "extra": {


### PR DESCRIPTION
PR allows the ability to support Easy Admin ^1.0 versions. e.g HOY is on EasyAdmin v1. (which we should eventually upgrade to v2)

```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - treetop1500/easyadmin-dragndrop-sort dev-master requires easycorp/easyadmin-bundle ^2.0 -> satisfiable by easycorp/easyadmin-bundle[2.2.1, 2.x-dev, v2.0.0, v2.0.0-BETA1, v2.0.0-BETA2, v2.0.0-RC1, v2.0.0-RC2, v2.0.1, v2.0.2, v2.0.3, v2.0.4, v2.0.5, v2.0.6, v2.1.0, v2.1.1, v2.1.2, v2.1.3, v2.1.4, v2.2.0, v2.2.2, v2.3.0, v2.3.1, v2.3.2, v2.3.3, v2.3.4, v2.3.5] but these conflict with your requirements or minimum-stability.
    - treetop1500/easyadmin-dragndrop-sort dev-master requires easycorp/easyadmin-bundle ~2.3 -> satisfiable by easycorp/easyadmin-bundle[2.x-dev, v2.3.0, v2.3.1, v2.3.2, v2.3.3, v2.3.4, v2.3.5] but these conflict with your requirements or minimum-stability.
    - treetop1500/easyadmin-dragndrop-sort dev-master requires easycorp/easyadmin-bundle ^2.0 -> satisfiable by easycorp/easyadmin-bundle[2.2.1, 2.x-dev, v2.0.0, v2.0.0-BETA1, v2.0.0-BETA2, v2.0.0-RC1, v2.0.0-RC2, v2.0.1, v2.0.2, v2.0.3, v2.0.4, v2.0.5, v2.0.6, v2.1.0, v2.1.1, v2.1.2, v2.1.3, v2.1.4, v2.2.0, v2.2.2, v2.3.0, v2.3.1, v2.3.2, v2.3.3, v2.3.4, v2.3.5] but these conflict with your requirements or minimum-stability.
    - Installation request for treetop1500/easyadmin-dragndrop-sort dev-master -> satisfiable by treetop1500/easyadmin-dragndrop-sort[dev-master].
```

@treetop1500 